### PR TITLE
Implement using `rustwide` to sandbox `cargo check` invocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,19 +3,19 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
 
 [[package]]
 name = "anstream"
@@ -68,31 +68,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "attohttpc"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
+dependencies = [
+ "base64",
+ "flate2",
+ "http",
+ "log",
+ "native-tls",
+ "url",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
-]
 
 [[package]]
 name = "base64"
@@ -141,18 +155,22 @@ dependencies = [
 name = "cargo-resolvediff"
 version = "1.0.2"
 dependencies = [
+ "anyhow",
  "camino",
  "cargo_metadata",
  "clap",
- "color-eyre",
  "crates_io_api",
  "itertools",
  "minijinja",
+ "rustwide",
  "semver",
  "serde",
  "serde_json",
+ "tempfile",
  "tinyvec",
+ "tokio",
  "toml_edit",
+ "uuid",
 ]
 
 [[package]]
@@ -176,6 +194,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -184,6 +204,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -236,33 +262,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
-name = "color-eyre"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
-dependencies = [
- "backtrace",
- "color-spantrace",
- "eyre",
- "indenter",
- "once_cell",
- "owo-colors",
- "tracing-error",
-]
-
-[[package]]
-name = "color-spantrace"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
-dependencies = [
- "once_cell",
- "owo-colors",
- "tracing-core",
- "tracing-error",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +301,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "cvt"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ae9bf77fbf2d39ef573205d554d87e86c12f1994e9ea335b0651b9b278bcf1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,26 +352,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foreign-types"
@@ -378,6 +405,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs_at"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14af6c9694ea25db25baa2a1788703b9e7c6648dcaeeebeb98f7561b5384c036"
+dependencies = [
+ "aligned",
+ "cfg-if",
+ "cvt",
+ "libc",
+ "nix 0.29.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -477,15 +518,35 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
 
 [[package]]
-name = "gimli"
-version = "0.32.3"
+name = "getrandom"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
+name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
 
 [[package]]
 name = "hashbrown"
@@ -702,12 +763,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indenter"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
-
-[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,6 +810,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,16 +830,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
+name = "libc"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "libgit2-sys"
+version = "0.18.5+1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c04141a07bb0c0bc461cb657808764de571702a59bc5c726c400ac9a7625e3ab"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -824,13 +923,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -855,21 +955,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "normpath"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9985ef7269fa99f3b12437bb698381da2428743ab90f20393f399fa14cab21a"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -929,12 +1053,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "owo-colors"
-version = "4.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +1110,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "remove_dir_all"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cc0b475acf76adf36f08ca49429b12aad9f678cb56143d5b3cb49b9a1dd08"
+dependencies = [
+ "cfg-if",
+ "cvt",
+ "fs_at",
+ "libc",
+ "normpath",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,12 +1168,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1064,10 +1196,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rustwide"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55e5e5d1bc12ace59ef13ae02f7a81abdc55bcf3f700d3fc5746ba264693b08a"
+dependencies = [
+ "anyhow",
+ "attohttpc",
+ "base64",
+ "flate2",
+ "futures-util",
+ "getrandom 0.4.3",
+ "git2",
+ "log",
+ "nix 0.30.1",
+ "percent-encoding",
+ "remove_dir_all",
+ "serde",
+ "serde_json",
+ "tar",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "toml",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -1172,6 +1342,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,19 +1363,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -1212,12 +1398,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1264,13 +1450,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1297,15 +1494,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,14 +1511,15 @@ checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "windows-sys 0.61.2",
 ]
@@ -1346,10 +1535,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -1361,26 +1585,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c740b185920170a6d9191122cafef7010bd6270a3824594bff6784c04d7f09e"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -1444,28 +1668,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-error"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
-dependencies = [
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
-dependencies = [
- "sharded-slab",
- "thread_local",
- "tracing-core",
 ]
 
 [[package]]
@@ -1505,16 +1707,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "valuable"
-version = "0.1.1"
+name = "uuid"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -1610,6 +1827,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,9 +1843,18 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
@@ -1635,11 +1870,10 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows-link",
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -1652,51 +1886,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.1"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.1"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.1"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.1"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.1"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.1"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.1"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.1"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -1706,6 +1940,12 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
@@ -1718,6 +1958,16 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,12 @@ serde_json = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }
 crates_io_api = "0.12"
 toml_edit = "0.24"
-color-eyre = "0.6"
+anyhow = "1"
 tinyvec = "1.10"
 itertools = { version = "0.14", default-features = false }
 clap = { version = "4.5.54", features = [ "derive" ] }
 minijinja = { version = "2.14", features = [ "loop_controls", "loader" ] }
+rustwide = "0.25.1"
+tokio = { version = "1.52", features = [ "process", "time" ] }
+uuid = { version = "1.24", features = [ "v4" ] }
+tempfile = "3.16.0"

--- a/README.md
+++ b/README.md
@@ -23,15 +23,19 @@ Dependencies are considered "pinned" & not updated as major updates automaticall
 
 ## Usage
 ```
+A tool for diffing `cargo` dependency resolutions between updates
+
+Usage: cargo-resolvediff [OPTIONS]
+
 Options:
       --manifest-path <MANIFEST_PATH>
           The path to the manifest of the workspace to update
-          
+
           It is assumed a `Cargo.lock` is present.
 
   -p, --platform <PLATFORM>
           The platform tuples to do dependency resolution for
-          
+
           Defaults to only the target tuple of the host if none are given.
 
   -P, --filter-to-platforms
@@ -40,8 +44,84 @@ Options:
 
   -c, --check
           Run `cargo check` for updates
-          
-          This may potentially not be desirable since it will run build dependencies.
+
+          This may potentially not be desirable since it will run build dependencies,
+          though by default these are sandboxed
+          (see the `--no-check-sandbox` option and all `--sandbox-...` options
+          for configuring the sandbox and its details).
+
+          Sandboxing requires the `--sandbox-rustwide-workspace`
+          or `--sandbox-rustwide-workspace-tmp` flag to be set.
+
+      --check-timeout <CHECK_TIMEOUT>
+          Require `check` to exit within this configured timeout
+          (in seconds ('s') by default).
+
+          This also supports the suffixes ms, min, h and d/day.
+
+      --check-no-sandbox
+          Run `cargo check` without a sandbox.
+
+          `cargo check` will run build dependencies,
+          but rustwide (the sandboxing solution used by this program) requires Docker
+          to work.
+
+          You should probably not use this flag if you can't use sandboxing
+          unless you're 100% sure you're fine with running untrusted code in your
+          environment.
+
+      --sandbox-rustwide-workspace <SANDBOX_RUSTWIDE_WORKSPACE>
+          The location of a permanent rustwide workspace.
+
+          Notably this is NOT the source of the checked crate,
+          and should not be contained therein either
+          (the crate source will be copied there, among other things)
+
+      --sandbox-rustwide-workspace-tmp
+          Create a rustwide workspace in `/tmp`.
+
+          Notably this will not work with `--sandbox-sibling-containers`
+          unless `/tmp` was pointing to a host directory.
+
+      --sandbox-image-local <SANDBOX_IMAGE_LOCAL>
+          Use a local docker image for the rustwide sandbox
+
+      --sandbox-image-remote <SANDBOX_IMAGE_REMOTE>
+          Use a remote docker image from a registry for the rustwide sandbox
+
+      --sandbox-fast-init
+          Prefer sandbox initialisation speed over runtime performance,
+          by installing tools in the docker image in debug mode for example.
+          This may be useful in CI environments
+
+      --sandbox-sibling-containers
+          Use the hosts docker instance to create sibling containers for rustwide.
+
+          This requires the docker socket (`/var/run/docker.sock`) to be mounted
+          in the container this application runs in,
+          and furthermore requires that the workspace directory is mounted somewhere
+          in the host system, using workspaces created in a container is not supported
+
+      --sandbox-rustup-profile <SANDBOX_RUSTUP_PROFILE>
+          The rustup profile to use when installing toolchains in rustwide.
+          The default is `minimal`
+
+      --sandbox-memory-limit <SANDBOX_MEMORY_LIMIT>
+          Set a memory limit for the sandbox container.
+
+          Set as a number with an optional suffix
+          (default is in bytes (B), as well as K, M, G, T or KB/KiB etc)
+
+      --sandbox-cpu-limit <SANDBOX_CPU_LIMIT>
+          Set a CPU limit for the sandbox container as a (fractional) number of cores
+          (ie 0.5 is half a core)
+
+      --sandbox-cpuset-cpus <SANDBOX_CPUSET_CPUS>
+          Restrict the sandbox container to specific CPU IDs as a range split by '-'
+          (translates to Dockers `--cpuset-cpus x-x`), ie `0-1` to select cores 0 & 1
+
+      --sandbox-enable-networking
+          Enable network access in the sandbox container
 
   -m, --major
           Do major updates (this edits `Cargo.toml` files)
@@ -64,18 +144,25 @@ Options:
   -t, --templated
           Produce templated output (or prettified JSON for missing templates)
 
+          For `--major`, this concatenates the templates for the minor updates,
+          and then the major update template per major update.
+
+  -t, --templated-as-squashed
+          Same as `--templated`,
+          but use the squashed template format by taking a diff over all changes
+
       --templated-in-json
           Same as `--templated`,
           but render the templates into strings in a JSON object with more information
-          
+
           This is also compatible with `--major`.
 
   -T, --template-path <TEMPLATE_PATH>
           The path to a directory containing minijinja templates
-          
-          This option makes sense outside of `--templated`/`--templated-in-json`, because
-          commits made using `--git` still use templating.
-          
+
+          This option makes sense outside of `--templated`/`--templated-in-json`,
+          because commits made using `--git` still use templating.
+
           The template names are:
           * `minor_commit.jinja`, `major_commit.jinja` and `squashed_commit.jinja`
             set the commit messages.
@@ -85,7 +172,7 @@ Options:
 
           The JSON dump for outputs (without `--templated`) is always the same
           as the context the associated template gets.
-          
+
           Extra context per template kind:
           * Output templates receive the commit hash if a new commit was made
             (via `--git`)
@@ -96,7 +183,7 @@ Options:
             with the keys `package` & `version`, pointing to strings each
           * `git_output.jinja`: `from` & `to` are both strings containing
             the commit hashes that were part of the comparison
-          
+
           Extra functions implemented:
           * `short_platform` (filter): Removes the last segment if it remains unique,
             and all `unknown` segments from platform tuples

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,72 +1,313 @@
 // Copyright (C) 2026 by GiGa infosystems
 
-//! See the documentation of [`cmd!`], a utility macro for running commands (in this case `git`,
+//! See the documentation of [`Command`], a utility type for running commands (in this case `git`,
 //! `cargo` and `rustc`).
 
-/// Run an external process
-///
-/// # Usage
-/// Example: `cmd!([cargo "generate-lockfile"] ["--manifest-path" (path)])`, where all segments
-/// (`cargo`, `"generate-lockfile"`, `"--manifest-path"` and `(path)`) can be either identifiers,
-/// which get stringified, literals or expressions in parentheses. The first set of arguments is
-/// also used in error reporting ("Failed to run `cargo generate-lockfile`").
-///
-/// If there are no further arguments, the second set of brackets is omitted.
-///
-/// Additionally, it may output a boolean (where the returned status code is either `0` mapped to
-/// `true` or `1` mapped to `false`) by adding `-> bool`, or alternatively the stdout output
-/// excluding a single trailing newline if it exists by adding `-> String`.
-///
-/// It may also be run in another working directory using `in path` (after potential return
-/// specifiers as explained above), where `path` is an expression of the type
-/// `Option<impl AsRef<Path>>`, or a reference to such a type.
-macro_rules! cmd {
-    (@arg $ident:ident) => { stringify!($ident) };
-    (@arg $literal:literal) => { $literal };
-    (@arg ($expr:expr)) => { $expr };
-    (@stdout $cmd:ident -> String) => { std::process::Stdio::piped() };
-    (@stdout $cmd:ident $(-> $ty:ident)?) => { std::io::stderr() };
-    (@success $out:ident -> bool) => { true };
-    (@success $out:ident $(-> $ty:ident)?) => { $out.status.success() };
-    (@out $out:ident -> bool) => { $out.status.success() };
-    (@out $out:ident -> String) => {{
-        let mut out = $out.stdout;
+use anyhow::{Result, bail, anyhow, Error};
+use std::ffi::{OsStr, OsString};
+use std::fmt::Write;
+use std::iter;
+use std::path::{Path, PathBuf};
+use std::process::{self, ExitStatus};
+use std::time::Duration;
 
+#[must_use]
+#[derive(Clone)]
+pub struct CommandBuilder<'a, 'b> {
+    sandbox: Option<&'b rustwide::Build<'a>>,
+    path: Option<&'b Path>,
+    timeout: Option<Duration>,
+}
+
+impl<'a, 'b> CommandBuilder<'a, 'b> {
+    pub const fn new() -> Self {
+        CommandBuilder {
+            sandbox: None,
+            path: None,
+            timeout: None,
+        }
+    }
+
+    pub const fn in_sandbox_maybe(self, sandbox: Option<&'b rustwide::Build<'a>>) -> Self {
+        CommandBuilder { sandbox, ..self }
+    }
+
+    pub const fn at_path_maybe(self, path: Option<&'b Path>) -> Self {
+        CommandBuilder { path, ..self }
+    }
+
+    pub const fn with_timeout_maybe(self, timeout: Option<Duration>) -> Self {
+        CommandBuilder { timeout, ..self }
+    }
+
+    pub fn cmd<const N: usize>(self, cmd: [&str; N]) -> Command<'a> {
+        const {
+            if N == 0 {
+                panic!("The command is empty");
+            }
+        };
+        let backend = match self.sandbox {
+            None => {
+                let mut cmd = std::process::Command::new(cmd[0]);
+                if let Some(path) = self.path {
+                    cmd.current_dir(path);
+                }
+                CommandBackend::Normal(cmd)
+            }
+            Some(sandbox) => {
+                let mut cmd = if cmd[0] == "cargo" {
+                    sandbox.cargo()
+                } else {
+                    sandbox.cmd(cmd[0])
+                };
+                if let Some(path) = self.path {
+                    cmd = cmd.current_directory(path);
+                }
+                CommandBackend::Sandboxed(cmd)
+            }
+        };
+
+        let mut out = Command {
+            name: cmd[0].to_owned(),
+            backend,
+            timeout: self.timeout,
+        };
+        for arg in &cmd[1..] {
+            write!(out.name, " {arg}").expect("this shouldn't fail");
+            out = out.arg(arg);
+        }
+        out
+    }
+}
+
+enum CommandBackend<'a> {
+    Normal(std::process::Command),
+    Sandboxed(rustwide::cmd::Command<'a, 'static>),
+}
+
+/// Used to run commands in a uniform manner regardless of sandboxed status, geared towards the
+/// use-cases of this crate (such as convenient accessing of stdout as a string with the final
+/// newline stripped, see [`Command::stdout`]).
+#[must_use]
+pub struct Command<'a> {
+    name: String,
+    timeout: Option<Duration>,
+    backend: CommandBackend<'a>,
+}
+
+impl<'a> Command<'a> {
+    pub const fn builder<'b>() -> CommandBuilder<'a, 'b> {
+        CommandBuilder::new()
+    }
+
+    /// Run an external command, to set more options see [`Command::builder`].
+    pub fn cmd<const N: usize>(cmd: [&str; N]) -> Self {
+        Self::builder().cmd(cmd)
+    }
+
+    pub fn arg(mut self, arg: impl ValidArg) -> Self {
+        for i in arg.as_args() {
+            match self.backend {
+                CommandBackend::Normal(ref mut cmd) => {
+                    cmd.arg(i);
+                }
+                CommandBackend::Sandboxed(cmd) => {
+                    self.backend = CommandBackend::Sandboxed(cmd.arg(i))
+                }
+            };
+        }
+        self
+    }
+
+    fn run_inner(self, capture_stdout: bool, assert_success: bool) -> Result<process::Output> {
+        let name = self.name;
+        let timeout_error = || {
+            anyhow!(
+                "Failed to run `{name}`, took longer than {:?}",
+                self.timeout
+            )
+        };
+        let assert_success = |status: ExitStatus| {
+            if assert_success && !status.success() {
+                bail!("Failed to run `{name}`, returned status code {status}");
+            } else {
+                Ok(())
+            }
+        };
+        match self.backend {
+            CommandBackend::Normal(mut cmd) => {
+                cmd.stderr(std::io::stderr());
+                if !capture_stdout {
+                    // Push all command output to stderr as well
+                    cmd.stdout(std::io::stderr());
+                }
+
+                let output = if let Some(timeout) = self.timeout {
+                    // `std` sadly doesn't have a nice way of creating timeouts, and `rustwide` uses
+                    // `tokio` anyways:
+                    tokio::runtime::LocalRuntime::new()?.block_on(async {
+                        tokio::time::timeout(timeout, tokio::process::Command::from(cmd).output())
+                            .await
+                            .map_err(|_| timeout_error())
+                            .and_then(|result| result.map_err(Error::from))
+                    })?
+                } else {
+                    cmd.output()?
+                };
+
+                assert_success(output.status)?;
+
+                Ok(output)
+            }
+            CommandBackend::Sandboxed(cmd) => {
+                let cmd = cmd
+                    .log_command(false)
+                    .log_output(false)
+                    .timeout(self.timeout);
+
+                let output = if capture_stdout {
+                    cmd.run_capture()
+                } else {
+                    // We sadly don't know if it's stdout or stderr :(
+                    cmd.process_lines(&mut |line, _| eprintln!("{line}"))
+                        .run_capture()
+                };
+
+                match output {
+                    Ok(output) => {
+                        if capture_stdout {
+                            for line in output.stderr_lines() {
+                                eprintln!("{line}");
+                            }
+                        }
+
+                        Ok(process::Output {
+                            status: ExitStatus::default(),
+                            stdout: output.stdout_lines().join("\n").into(),
+                            stderr: Vec::new(),
+                        })
+                    }
+                    Err(rustwide::cmd::CommandError::ExecutionFailed { status, stderr }) => {
+                        // We didn't emit stderr in `process_lines` earlier, stdout is sadly now
+                        // lost
+                        if capture_stdout {
+                            eprintln!("{stderr}");
+                        }
+
+                        assert_success(status)?;
+                        Ok(process::Output {
+                            status,
+                            stdout: Vec::new(), // sadly not recoverable
+                            stderr: stderr.into(),
+                        })
+                    }
+                    // In these two cases, if stdout was captured, we sadly don't know stderr
+                    // anymore:
+                    Err(rustwide::cmd::CommandError::Timeout(_)) => Err(timeout_error()),
+                    Err(other) => Err(other.into()),
+                }
+            }
+        }
+    }
+
+    /// Run the command, failing on non-zero exit statuses, and not capturing stdout
+    pub fn run(self) -> Result<()> {
+        self.run_inner(false, true)?;
+        Ok(())
+    }
+
+    /// Run the command, not capturing stdout, returning `true` if the exit status was zero
+    #[expect(clippy::wrong_self_convention)]
+    pub fn is_success(self) -> Result<bool> {
+        let out = self.run_inner(false, false)?.status.success();
+        Ok(out)
+    }
+
+    /// Run the command, failing on non-zero exit statuses, and capturing stdout and returning it,
+    /// with the final newline removed if there was one (ie for the output of
+    /// `rustc --print host-tuple`)
+    pub fn stdout(self) -> Result<String> {
+        let mut out = self.run_inner(true, true)?.stdout;
         if out.last() == Some(&b'\n') {
             out.pop();
         }
-
-        String::from_utf8(out)?
-    }};
-    (@out $out:ident) => { () };
-    ([$cmd0:tt $($cmd_args:tt)*] $([$($args:tt)*])? $(-> $ret:tt)? $(in $path:expr)?) => {{
-        let cmd0 = $crate::cmd::cmd!(@arg $cmd0);
-        let cmd_args: [&str;_] = [$($crate::cmd::cmd!(@arg $cmd_args)),*];
-        let mut cmd = std::process::Command::new(cmd0);
-        cmd.args(&cmd_args)
-            $($(.arg($crate::cmd::cmd!(@arg $args)))?)?;
-
-        $(
-            if let Some(path) = $path {
-                cmd.current_dir(path);
-            }
-        )?
-
-        cmd.stdout($crate::cmd::cmd!(@stdout cmd $(-> $ret)?));
-
-        let output = cmd.spawn()?.wait_with_output()?;
-
-        if !$crate::cmd::cmd!(@success output $(-> $ret)?) {
-            color_eyre::eyre::bail!(
-                "Failed to run `{} {}`, returned status code {}",
-                cmd0,
-                cmd_args.join(" "),
-                output.status,
-            );
-        }
-
-        <color_eyre::Result<_>>::Ok($crate::cmd::cmd!(@out output $(-> $ret)?))
-    }};
+        Ok(String::from_utf8(out)?)
+    }
 }
 
-pub(crate) use cmd;
+pub trait ValidArg {
+    fn as_args(&self) -> impl Iterator<Item = &OsStr>;
+}
+
+impl<T: ValidArg + ?Sized> ValidArg for &'_ T {
+    fn as_args(&self) -> impl Iterator<Item = &OsStr> {
+        T::as_args(self)
+    }
+}
+
+impl ValidArg for OsStr {
+    fn as_args(&self) -> impl Iterator<Item = &OsStr> {
+        iter::once(self)
+    }
+}
+
+impl ValidArg for OsString {
+    fn as_args(&self) -> impl Iterator<Item = &OsStr> {
+        OsStr::as_args(&**self)
+    }
+}
+
+impl ValidArg for str {
+    fn as_args(&self) -> impl Iterator<Item = &OsStr> {
+        iter::once(self.as_ref())
+    }
+}
+
+impl ValidArg for String {
+    fn as_args(&self) -> impl Iterator<Item = &OsStr> {
+        str::as_args(self)
+    }
+}
+
+impl ValidArg for Path {
+    fn as_args(&self) -> impl Iterator<Item = &OsStr> {
+        iter::once(self.as_ref())
+    }
+}
+
+impl ValidArg for PathBuf {
+    fn as_args(&self) -> impl Iterator<Item = &OsStr> {
+        Path::as_args(self)
+    }
+}
+
+impl<T: ValidArg> ValidArg for Option<T> {
+    fn as_args(&self) -> impl Iterator<Item = &OsStr> {
+        self.as_ref().into_iter().flat_map(|inner| inner.as_args())
+    }
+}
+
+impl<T: ValidArg> ValidArg for [T] {
+    fn as_args(&self) -> impl Iterator<Item = &OsStr> {
+        self.iter().flat_map(|inner| inner.as_args())
+    }
+}
+
+impl<T: ValidArg, const N: usize> ValidArg for [T; N] {
+    fn as_args(&self) -> impl Iterator<Item = &OsStr> {
+        <[T]>::as_args(self)
+    }
+}
+
+impl<T: ValidArg> ValidArg for Vec<T> {
+    fn as_args(&self) -> impl Iterator<Item = &OsStr> {
+        <[T]>::as_args(self)
+    }
+}
+
+/// This makes flags with arguments much nicer
+impl<T: ValidArg> ValidArg for (&str, T) {
+    fn as_args(&self) -> impl Iterator<Item = &OsStr> {
+        self.0.as_args().chain(self.1.as_args())
+    }
+}

--- a/src/git.rs
+++ b/src/git.rs
@@ -2,8 +2,8 @@
 
 //! Git helpers for the application to add changes & commit them
 
-use crate::cmd::cmd;
-use color_eyre::Result;
+use crate::cmd::Command;
+use anyhow::Result;
 use std::path::{Path, PathBuf};
 
 /// A `git` repository
@@ -23,19 +23,30 @@ impl Repository {
         Repository { path, dirty: false }
     }
 
+    fn cmd<const N: usize>(&self, cmd: [&str; N]) -> Command<'_> {
+        Command::builder()
+            .at_path_maybe(self.path.as_deref())
+            .cmd(cmd)
+    }
+
     /// `git add` a given path if it includes changes.
     pub fn add(&mut self, path: &Path) -> Result<()> {
-        let changed = !cmd!([git diff] ["-s" "--exit-code" "--" (path)] -> bool in &self.path)?;
+        let changed = !self
+            .cmd(["git", "diff"])
+            .arg(["-s", "--exit-code"])
+            .arg("--")
+            .arg(path)
+            .is_success()?;
         if changed {
             self.dirty = true;
-            cmd!([git add] [(path)] in &self.path)?;
+            self.cmd(["git", "add"]).arg(path).run()?;
         }
         Ok(())
     }
 
     /// Returns the current commit ID
     pub fn current_commit(&self) -> Result<String> {
-        cmd!([git "rev-parse"] [HEAD] -> String in &self.path)
+        self.cmd(["git", "rev-parse"]).arg("HEAD").stdout()
     }
 
     /// `git commit` everything that got added, if there were any changes, and return the commit
@@ -46,14 +57,14 @@ impl Repository {
         if !self.dirty {
             return Ok(None);
         }
-        cmd!([git commit] ["-m" (message)] in &self.path)?;
+        self.cmd(["git", "commit"]).arg(("-m", message)).run()?;
         self.dirty = false;
         Ok(Some(self.current_commit()?))
     }
 
     /// Returns the current branch, if any, or the current commit ID
     pub fn current_branch_or_commit(&self) -> Result<String> {
-        let branch = cmd!([git branch] ["--show-current"] -> String in &self.path)?;
+        let branch = self.cmd(["git", "branch"]).arg("--show-current").stdout()?;
         if !branch.is_empty() {
             Ok(branch)
         } else {
@@ -63,6 +74,6 @@ impl Repository {
 
     /// Checks out a given branch or commit ID
     pub fn checkout(&mut self, target: &str) -> Result<()> {
-        cmd!([git "checkout"] [(target)] in &self.path)
+        self.cmd(["git", "checkout"]).arg(target).run()
     }
 }

--- a/src/indexed.rs
+++ b/src/indexed.rs
@@ -7,7 +7,7 @@ use std::{collections::HashMap, path::Path};
 use crate::Platform;
 use camino::Utf8PathBuf;
 use cargo_metadata::{MetadataCommand, Node, Package, PackageId};
-use color_eyre::Result;
+use anyhow::Result;
 
 /// The indexed output of `cargo metadata`
 #[derive(Debug)]
@@ -42,7 +42,7 @@ impl IndexedMetadata {
         other_options.push("--locked".to_owned());
 
         let data = MetadataCommand::new()
-            .manifest_path(path)
+            .current_dir(path)
             .other_options(other_options)
             .exec()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,12 +4,10 @@
 // `cargo metadata` outside of parsing the source.
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use clap::Parser;
-use color_eyre::{
-    Result,
-    eyre::{Report, bail},
-};
+use anyhow::{Result, bail, anyhow};
 use crates_io_api::SyncClient;
 use semver::Version;
 use serde::Serialize;
@@ -21,7 +19,9 @@ use cargo_resolvediff::major_updates::{
     LatestVersion, ManifestDependencySet, fetch_latest_major_update_for,
 };
 use cargo_resolvediff::resolve::{Resolved, SpecificCrateIdent};
-use cargo_resolvediff::util::{host_platform, locate_project, update};
+use cargo_resolvediff::util::{
+    check, detect_toolchain, fetch, host_platform, locate_project, update,
+};
 
 struct OutputConfig {
     templated_output: bool,
@@ -330,9 +330,77 @@ struct Args {
     filter_to_platforms: bool,
     /// Run `cargo check` for updates
     ///
-    /// This may potentially not be desirable since it will run build dependencies.
+    /// This may potentially not be desirable since it will run build dependencies, though by
+    /// default these are sandboxed (see the `--no-check-sandbox` option and all `--sandbox-...`
+    /// options for configuring the sandbox and its details).
+    ///
+    /// Sandboxing requires the `--sandbox-rustwide-workspace` or `--sandbox-rustwide-workspace-tmp`
+    /// flag to be set.
     #[arg(short = 'c', long)]
     check: bool,
+    /// Require `check` to exit within this configured timeout (in seconds ('s') by default).
+    ///
+    /// This also supports the suffixes ms, min, h and d/day.
+    #[arg(long, requires("check"))]
+    check_timeout: Option<String>,
+    /// Run `cargo check` without a sandbox.
+    ///
+    /// `cargo check` will run build dependencies, but rustwide (the sandboxing solution used by
+    /// this program) requires Docker to work.
+    ///
+    /// You should probably not use this flag if you can't use sandboxing unless you're 100% sure
+    /// you're fine with running untrusted code in your environment.
+    #[arg(long, requires("check"))]
+    check_no_sandbox: bool,
+    /// The location of a permanent rustwide workspace.
+    ///
+    /// Notably this is NOT the source of the checked crate, and should not be contained therein
+    /// either (the crate source will be copied there, among other things).
+    #[arg(long, requires("check"))]
+    sandbox_rustwide_workspace: Option<PathBuf>,
+    /// Create a rustwide workspace in `/tmp`.
+    ///
+    /// Notably this will not work with `--sandbox-sibling-containers` unless `/tmp` was pointing to
+    /// a host directory.
+    #[arg(long, requires("check"), conflicts_with("sandbox_rustwide_workspace"))]
+    sandbox_rustwide_workspace_tmp: bool,
+    /// Use a local docker image for the rustwide sandbox
+    #[arg(long, requires("check"), conflicts_with("check_no_sandbox"))]
+    sandbox_image_local: Option<String>,
+    /// Use a remote docker image from a registry for the rustwide sandbox
+    #[arg(long, requires("check"), conflicts_with_all(["check_no_sandbox", "sandbox_image_local"]))]
+    sandbox_image_remote: Option<String>,
+    /// Prefer sandbox initialisation speed over runtime performance, by installing tools in the
+    /// docker image in debug mode for example. This may be useful in CI environments.
+    #[arg(long, requires("check"), conflicts_with("check_no_sandbox"))]
+    sandbox_fast_init: bool,
+    /// Use the hosts docker instance to create sibling containers for rustwide.
+    ///
+    /// This requires the docker socket (`/var/run/docker.sock`) to be mounted in the container this
+    /// application runs in, and furthermore requires that the workspace directory is mounted
+    /// somewhere in the host system, using workspaces created in a container is not supported.
+    #[arg(long, requires("check"), conflicts_with("check_no_sandbox"))]
+    sandbox_sibling_containers: bool,
+    /// The rustup profile to use when installing toolchains in rustwide. The default is `minimal`.
+    #[arg(long, requires("check"), conflicts_with("check_no_sandbox"))]
+    sandbox_rustup_profile: Option<String>,
+    /// Set a memory limit for the sandbox container.
+    ///
+    /// Set as a number with an optional suffix (default is in bytes (B), as well as K, M, G, T or
+    /// KB/KiB etc)
+    #[arg(long, requires("check"), conflicts_with("check_no_sandbox"))]
+    sandbox_memory_limit: Option<String>,
+    /// Set a CPU limit for the sandbox container as a (fractional) number of cores (ie 0.5 is half
+    /// a core).
+    #[arg(long, requires("check"), conflicts_with("check_no_sandbox"))]
+    sandbox_cpu_limit: Option<f32>,
+    /// Restrict the sandbox container to specific CPU IDs as a range split by '-' (translates to
+    /// Dockers `--cpuset-cpus x-x`), ie `0-1` to select cores 0 & 1.
+    #[arg(long, requires("check"), conflicts_with("check_no_sandbox"))]
+    sandbox_cpuset_cpus: Option<String>,
+    /// Enable network access in the sandbox container.
+    #[arg(long, requires("check"), conflicts_with("check_no_sandbox"))]
+    sandbox_enable_networking: bool,
     /// Do major updates (this edits `Cargo.toml` files)
     #[arg(short = 'm', long, requires("git"))]
     major: bool,
@@ -364,7 +432,7 @@ struct Args {
     /// Same as `--templated`, but render the templates into strings in a JSON object with more
     /// information
     ///
-    /// This is also compatible with `--major` _and_.
+    /// This is also compatible with `--major`.
     #[arg(long, conflicts_with_all(["templated", "templated_as_squashed"]))]
     templated_in_json: bool,
     /// The path to a directory containing minijinja templates
@@ -402,21 +470,57 @@ enum Task {
     },
 }
 
-struct AppContext {
-    manifest_path: PathBuf,
+struct RunCheck<'a, 'b> {
+    sandbox: Option<&'a rustwide::Build<'b>>,
+    timeout: Option<Duration>,
+}
+
+struct AppContext<'a, 'b> {
+    manifest_directory: PathBuf,
     lock_path: PathBuf,
     platforms: Vec<Platform>,
     include_all_platforms: bool,
-    check: bool,
+    check: Option<RunCheck<'a, 'b>>,
     repository: Option<Repository>,
     output: OutputConfig,
     task: Task,
 }
 
-impl TryFrom<Args> for AppContext {
-    type Error = Report;
+fn parse_suffixes(mut input: &str, suffixes: &[(&str, f64)]) -> Result<f64> {
+    let mut out = 0.;
+    while let Some(suffix_start) = input.find(|c| !matches!(c, '0'..='9' | '.')) {
+        let (number, suffix_rest) = input.split_at(suffix_start);
+        let (suffix, rest) = suffix_rest
+            .find(|c| matches!(c, '0'..='9' | '.' | ' '))
+            .map_or((suffix_rest, ""), |idx| suffix_rest.split_at(idx));
+        input = rest.trim();
 
-    fn try_from(args: Args) -> Result<Self> {
+        let number = number.parse::<f64>()?;
+        let (_, suffix_value) = suffixes
+            .iter()
+            .scan(1., |accumulated_value, (name, value)| {
+                *accumulated_value *= value;
+                Some((name, *accumulated_value))
+            })
+            .find(|(name, _)| suffix.eq_ignore_ascii_case(name))
+            .ok_or_else(|| anyhow!("Unknown suffix {suffix:?}"))?;
+
+        out += number * suffix_value;
+    }
+
+    if input.is_empty() {
+        Ok(out)
+    } else {
+        Ok(out + input.parse::<f64>()?)
+    }
+}
+
+/// Create a context
+impl AppContext<'_, '_> {
+    fn with_context_from<T>(
+        args: Args,
+        f: impl FnOnce(AppContext<'_, '_>) -> Result<T>,
+    ) -> Result<T> {
         let manifest_path = args.manifest_path.map_or_else(locate_project, Ok)?;
         if manifest_path.extension() != Some("toml".as_ref()) {
             bail!("A manifest path should in \".toml\", found {manifest_path:?}");
@@ -424,19 +528,69 @@ impl TryFrom<Args> for AppContext {
 
         let lock_path = manifest_path.with_extension("lock");
 
+        let mut manifest_directory = manifest_path.canonicalize()?;
+        assert!(manifest_directory.pop(), "there was a file name");
+
         let platforms = if args.platform.is_empty() {
             vec![host_platform()?]
         } else {
             args.platform.into_iter().map(Platform).collect::<Vec<_>>()
         };
 
-        let mut repository = args.git.then(|| {
-            let repository_path = manifest_path.parent().expect("there was a file name");
-            // We might already be in the directory with the `Cargo.toml`, in which case `git`
-            // commands can run here:
-            let repository_path = (repository_path != "").then(|| repository_path.to_owned());
-            Repository::new(repository_path)
-        });
+        let check_timeout = args
+            .check_timeout
+            .map(|s| {
+                parse_suffixes(
+                    &s,
+                    &[
+                        ("ms", 0.001),
+                        ("s", 1000.),
+                        ("min", 60.),
+                        ("h", 60.),
+                        ("d", 24.),
+                        ("day", 1.),
+                    ],
+                )
+            })
+            .transpose()?
+            .map(Duration::from_secs_f64);
+
+        let sandbox_memory_limit = args
+            .sandbox_memory_limit
+            .map(|s| {
+                parse_suffixes(
+                    &s,
+                    &[
+                        ("b", 1.),
+                        ("k", 1024.),
+                        ("kb", 1.),
+                        ("kib", 1.),
+                        ("m", 1024.),
+                        ("mb", 1.),
+                        ("mib", 1.),
+                        ("g", 1024.),
+                        ("gb", 1.),
+                        ("gib", 1.),
+                        ("t", 1024.),
+                        ("tb", 1.),
+                        ("tib", 1.),
+                    ],
+                )
+            })
+            .transpose()?
+            .map(|float| float as usize);
+
+        let sandbox_cpuset_cpus = args
+            .sandbox_cpuset_cpus
+            .map(|range| -> Result<_> {
+                let (lower, upper) = range.split_once("-").unwrap_or((&range, &range));
+                Ok(lower.parse::<usize>()?..=upper.parse()?)
+            })
+            .transpose()?;
+
+        let mut repository = args
+            .git
+            .then(|| Repository::new(Some(manifest_directory.clone())));
 
         let output = OutputConfig {
             templated_output: args.templated || args.templated_as_squashed,
@@ -463,16 +617,96 @@ impl TryFrom<Args> for AppContext {
             Task::Minor
         };
 
-        Ok(AppContext {
-            manifest_path,
+        let ctx = AppContext {
+            manifest_directory,
             lock_path,
             platforms,
             include_all_platforms: !args.filter_to_platforms,
-            check: args.check,
+            check: None, // filled below
             repository,
             output,
             task,
-        })
+        };
+
+        if args.check {
+            if !args.check_no_sandbox {
+                eprintln!("Building workspace");
+
+                let tmp_dir;
+                let rustwide_dir = if let Some(ref dir) = args.sandbox_rustwide_workspace {
+                    dir
+                } else if args.sandbox_rustwide_workspace_tmp {
+                    tmp_dir = tempfile::tempdir()?;
+                    tmp_dir.path()
+                } else {
+                    bail!(
+                        "Sandboxing requires --sandbox-rustwide-workspace \
+                         or --sandbox-rustwide-workspace-tmp",
+                    );
+                };
+
+                let mut builder =
+                    rustwide::WorkspaceBuilder::new(rustwide_dir, "cargo-resolvediff")
+                        .fast_init(args.sandbox_fast_init)
+                        .running_inside_docker(args.sandbox_sibling_containers);
+
+                if let Some(local) = args.sandbox_image_local {
+                    builder = builder.sandbox_image(rustwide::cmd::SandboxImage::local(&local)?);
+                } else if let Some(remote) = args.sandbox_image_remote {
+                    builder = builder.sandbox_image(rustwide::cmd::SandboxImage::remote(&remote)?);
+                }
+
+                if let Some(profile) = args.sandbox_rustup_profile {
+                    builder = builder.rustup_profile(&profile);
+                }
+
+                let workspace = builder.init()?;
+
+                let name = ctx
+                    .manifest_directory
+                    .file_name()
+                    .and_then(std::ffi::OsStr::to_str)
+                    .unwrap_or("project");
+                let random = uuid::Uuid::new_v4();
+                let mut build_dir = workspace.build_dir(&format!("{name}-{random}"));
+
+                let sandbox = rustwide::cmd::SandboxBuilder::new()
+                    .memory_limit(sandbox_memory_limit)
+                    .cpu_limit(args.sandbox_cpu_limit)
+                    .cpuset_cpus(sandbox_cpuset_cpus)
+                    .enable_networking(args.sandbox_enable_networking);
+
+                let toolchain =
+                    rustwide::Toolchain::dist(&detect_toolchain(&ctx.manifest_directory)?);
+                let krate = rustwide::Crate::local(&ctx.manifest_directory);
+                krate.fetch(&workspace)?;
+
+                let out = build_dir
+                    .build(&toolchain, &krate, sandbox)
+                    .run(|sandbox| {
+                        Ok(f(AppContext {
+                            check: Some(RunCheck {
+                                sandbox: Some(sandbox),
+                                timeout: check_timeout,
+                            }),
+                            ..ctx
+                        }))
+                    })
+                    .and_then(|result| result.into_inner());
+
+                build_dir.purge().and(out)
+            } else {
+                f(AppContext {
+                    check: Some(RunCheck {
+                        sandbox: None,
+                        timeout: check_timeout,
+                    }),
+                    ..ctx
+                })
+            }
+        } else {
+            f(ctx)
+        }
     }
 }
 
@@ -549,13 +783,28 @@ struct MajorUpdates {
     failed_major_updates: Vec<SpecificCrateIdent>,
 }
 
-impl AppContext {
-    fn try_update(&self) -> Result<bool> {
-        update(&self.manifest_path, self.check)
+/// Implementation of the actual program
+impl AppContext<'_, '_> {
+    fn try_update_lockfile_and_check(&self) -> Result<bool> {
+        if !fetch(&self.manifest_directory)? {
+            return Ok(false);
+        }
+
+        if let Some(ref run_check) = self.check {
+            check(
+                &self.manifest_directory,
+                run_check.sandbox,
+                run_check.timeout,
+            )
+        } else {
+            Ok(true)
+        }
     }
 
     fn minor_update(&self) -> Result<()> {
-        if !self.try_update()? {
+        eprintln!("Doing minor updates");
+
+        if !update(&self.manifest_directory)? || !self.try_update_lockfile_and_check()? {
             bail!("Minor updates failed");
         }
 
@@ -563,8 +812,9 @@ impl AppContext {
     }
 
     fn resolve(&self) -> Result<Resolved> {
+        eprintln!("Collecting cargo resolution metadata");
         Resolved::resolve_from_path(
-            &self.manifest_path,
+            &self.manifest_directory,
             self.platforms.iter().cloned(),
             self.include_all_platforms,
         )
@@ -602,13 +852,15 @@ impl AppContext {
         major_ctx.manifest_deps.commit()?;
 
         for package in direct_dependencies {
+            eprintln!("Updating {package}");
+
             major_ctx.manifest_deps.roll_back()?;
 
             let Some(package) = major_ctx.update_for(package)? else {
                 continue;
             };
 
-            if !self.try_update()? {
+            if !self.try_update_lockfile_and_check()? {
                 failed_major_updates.push(package);
                 continue;
             };
@@ -665,19 +917,24 @@ impl AppContext {
 
         major_ctx.manifest_deps.commit()?;
         for package in direct_dependencies {
+            eprintln!("Checking {package}");
+
             major_ctx.manifest_deps.roll_back()?;
 
             let Some(package) = major_ctx.update_for(package)? else {
+                eprintln!("Skipping, since there are no relevant updates");
                 continue;
             };
 
-            if !self.try_update()? {
+            if !self.try_update_lockfile_and_check()? {
                 failed_major_updates.push(package);
+                eprintln!("Failed");
                 continue;
             };
 
             major_ctx.manifest_deps.commit()?;
             major_updates.push(package);
+            eprintln!("Succeeded");
         }
 
         self.minor_update()?;
@@ -732,22 +989,20 @@ impl AppContext {
 }
 
 fn main() -> Result<()> {
-    color_eyre::install()?;
+    AppContext::with_context_from(Args::parse(), |mut ctx| {
+        let out = match ctx.task.clone() {
+            Task::Minor => ctx.minor_update_task()?.1,
+            Task::Major => ctx.major_update_task()?,
+            Task::Squashed => ctx.squashed_update_task()?,
+            Task::Git {
+                from,
+                to,
+                return_to,
+            } => ctx.git_task(&from, &to, &return_to)?,
+        };
 
-    let mut ctx = AppContext::try_from(Args::parse())?;
+        ctx.output.final_output(&out)?;
 
-    let out = match ctx.task.clone() {
-        Task::Minor => ctx.minor_update_task()?.1,
-        Task::Major => ctx.major_update_task()?,
-        Task::Squashed => ctx.squashed_update_task()?,
-        Task::Git {
-            from,
-            to,
-            return_to,
-        } => ctx.git_task(&from, &to, &return_to)?,
-    };
-
-    ctx.output.final_output(&out)?;
-
-    Ok(())
+        Ok(())
+    })
 }

--- a/src/major_updates.rs
+++ b/src/major_updates.rs
@@ -6,7 +6,7 @@ use crate::{
     indexed::IndexedMetadata,
     toml_edit::{MutableTomlFile, TomlPathLookup},
 };
-use color_eyre::{Result, eyre::eyre};
+use anyhow::{Result, anyhow};
 use crates_io_api::SyncClient;
 use itertools::Itertools;
 use semver::{Version, VersionReq};
@@ -162,7 +162,7 @@ impl ManifestDependencySet {
             .get("target")
             .map(|target| {
                 target.as_table_like().ok_or_else(|| {
-                    eyre!("Invalid target table in {:?} at `target`", manifest.path())
+                    anyhow!("Invalid target table in {:?} at `target`", manifest.path())
                 })
             })
             .transpose()?
@@ -189,7 +189,7 @@ impl ManifestDependencySet {
             .expect("Version path lookup failed (maybe the `MutableTomlFile` changed?)")
             .as_str()
             .ok_or_else(|| {
-                eyre!(
+                anyhow!(
                     "Invalid `version`/immediate value in {path:?} at {:?}",
                     manifest.path()
                 )
@@ -210,7 +210,7 @@ impl ManifestDependencySet {
             };
 
             let dependencies = dependencies.as_table_like().ok_or_else(|| {
-                eyre!(
+                anyhow!(
                     "Invalid dependency table in {:?} at {dep_path}",
                     manifest.path()
                 )
@@ -222,7 +222,7 @@ impl ManifestDependencySet {
                         let package = match dependency.get("package") {
                             None => name,
                             Some(package) => package.as_str().ok_or_else(|| {
-                                eyre!(
+                                anyhow!(
                                     "Invalid `package` value in {:?} at {dep_path}.{name:?}",
                                     manifest.path()
                                 )
@@ -321,7 +321,7 @@ impl ManifestDependencySet {
         if errors.is_empty() {
             Ok(())
         } else {
-            Err(eyre!("Failed to roll back:\n{errors:?}"))
+            Err(anyhow!("Failed to roll back:\n{errors:?}"))
         }
     }
 }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -7,7 +7,7 @@ use crate::Platform;
 use crate::indexed::IndexedMetadata;
 use camino::{Utf8Path, Utf8PathBuf};
 use cargo_metadata::PackageId;
-use color_eyre::Result;
+use anyhow::Result;
 use semver::Version;
 use serde::Serialize;
 use std::{
@@ -429,18 +429,18 @@ impl Resolved {
 
     /// Resolve everything for a given root manifest for the given set of platforms
     pub fn resolve_from_path(
-        root_cargo_toml: &Path,
+        root_directory: &Path,
         specific_platforms: impl IntoIterator<Item = Platform>,
         include_all_platforms: bool,
     ) -> Result<Self> {
         let mut included = itertools::process_results(
             specific_platforms
                 .into_iter()
-                .map(|platform| IndexedMetadata::gather(root_cargo_toml, Some(platform))),
+                .map(|platform| IndexedMetadata::gather(root_directory, Some(platform))),
             |iter| Self::resolve_from_indexed(iter),
         )?;
 
-        let full_metadata = IndexedMetadata::gather(root_cargo_toml, None)?;
+        let full_metadata = IndexedMetadata::gather(root_directory, None)?;
         let out = if include_all_platforms {
             Self::resolve_platform(&full_metadata, &mut included);
             Resolved {

--- a/src/toml_edit.rs
+++ b/src/toml_edit.rs
@@ -2,7 +2,7 @@
 
 //! Utilities for editing `Cargo.toml` manifests
 
-use color_eyre::Result;
+use anyhow::Result;
 use std::fs;
 use std::path::{Path, PathBuf};
 use toml_edit::{DocumentMut, Item};

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,34 +2,82 @@
 
 //! Various utility functions associated with this crate
 
-use crate::Platform;
-use crate::cmd::cmd;
-use color_eyre::Result;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
-/// Do a `cargo update` for the given root `Cargo.toml` manifest, optionally running `cargo check`
-/// and returning if it succeeded
-pub fn update(path: &Path, check: bool) -> Result<bool> {
-    if !cmd!([cargo update] ["--manifest-path" (path)] -> bool)? {
-        return Ok(false);
-    }
+use crate::Platform;
+use crate::cmd::Command;
+use anyhow::{Context, Result};
 
-    if check && !cmd!([cargo check] ["--manifest-path" (path) "--all-targets"] -> bool)? {
-        return Ok(false);
-    }
+/// Do a `cargo update` for the given root `Cargo.toml` manifest
+pub fn update(path: &Path) -> Result<bool> {
+    Command::builder()
+        .at_path_maybe(Some(path))
+        .cmd(["cargo", "update"])
+        .is_success()
+}
 
-    Ok(true)
+pub fn fetch(path: &Path) -> Result<bool> {
+    Command::builder()
+        .at_path_maybe(Some(path))
+        .cmd(["cargo", "fetch"])
+        .is_success()
+}
+
+/// Run `cargo check`, optionally in a [`rustwide`] sandbox
+pub fn check(
+    path: &Path,
+    sandbox: Option<&rustwide::Build<'_>>,
+    timeout: Option<Duration>,
+) -> Result<bool> {
+    let no_sandbox = sandbox.is_none();
+    Command::builder()
+        .in_sandbox_maybe(sandbox)
+        .with_timeout_maybe(timeout)
+        .at_path_maybe(no_sandbox.then_some(path))
+        .cmd(["cargo", "check"])
+        .arg("--all-targets")
+        .is_success()
 }
 
 /// Locate the root `Cargo.toml` from the current working directory
 pub fn locate_project() -> Result<PathBuf> {
-    let out =
-        cmd!([cargo "locate-project"] ["--workspace" "--message-format" plain] -> String)?.into();
+    let out = Command::cmd(["cargo", "locate-project"])
+        .arg("--workspace")
+        .arg(("--message-format", "plain"))
+        .stdout()?
+        .into();
+    Ok(out)
+}
+
+/// Detect the downloadable toolchain name based on the resolved rustc for the cargo manifest
+/// directory
+pub fn detect_toolchain(path: &Path) -> Result<String> {
+    let out = Command::builder()
+        .at_path_maybe(Some(path))
+        .cmd(["rustc", "--version"])
+        .stdout()?;
+    let date = out
+        .rsplit_once(' ')
+        .and_then(|(_, s)| s.strip_suffix(')'))
+        .context("`rustc --version` should have '({commit} {date})` as the end of its output")?;
+    let out = if out.contains("nightly") {
+        format!("nightly-{date}")
+    } else if out.contains("beta") {
+        format!("beta-{date}")
+    } else {
+        out.split(' ')
+            .nth(1)
+            .context(
+                "`rustc --version` should have `rustc {version}` as the beginning of its output",
+            )?
+            .to_owned()
+    };
     Ok(out)
 }
 
 /// Return the host platform tuple
 pub fn host_platform() -> Result<Platform> {
-    let platform_tuple = cmd!([rustc "--print" "host-tuple"] -> String)?;
+    let platform_tuple = Command::cmd(["rustc", "--print", "host-tuple"]).stdout()?;
     Ok(Platform(platform_tuple))
 }


### PR DESCRIPTION
This also:
* Extends `cmd::cmd!` to work with optional arguments (and for
  completeness lists of arguments as well)
* Extends `cmd::cmd!` to run in a sandbox, or to optionally do so
* Adds more stderr outputs to show which operation is currently
  happening (and might be hanging) - especially the sandbox creation can
  take a while the first time since it needs to pull an image from
  GitHub Actions that is quite large
* Adds support for all the sandboxing flags, including timeouts
* Adds support for timeouts outside of the sandbox as well for
  completeness
* Fixes a bug: Previously the first major update would do an implicit
  full minor update, as it was running `cargo update` to update the
  lockfile. That was a regression due to changing the order of
  minor/major updates, previously this had the correct behaviour.
  A `cargo fetch` handles that better.
* Minor documentation fixes
* Switch to `anyhow` from `color_eyre` as that's what `rustwide` also uses
* Switch from `--manifest-path` to setting the working directory, that
  way rustup can select a different toolchain if appropriate
