### PR TITLE
Fix version selection and out of platform removals

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -3,7 +3,7 @@
 //! See the documentation of [`Command`], a utility type for running commands (in this case `git`,
 //! `cargo` and `rustc`).
 
-use anyhow::{Result, bail, anyhow, Error};
+use anyhow::{Error, Result, anyhow, bail};
 use std::ffi::{OsStr, OsString};
 use std::fmt::Write;
 use std::iter;

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -91,6 +91,14 @@ pub struct Diff<'a> {
     pub filtered_removed: Vec<SpecificCrateIdent>,
 }
 
+fn version_diff(a: &Version, b: &Version) -> (u64, u64, u64) {
+    (
+        a.major.abs_diff(b.major),
+        a.minor.abs_diff(b.minor),
+        a.patch.abs_diff(b.patch),
+    )
+}
+
 impl<'a> Diff<'a> {
     fn compare(
         name: &'a str,
@@ -100,11 +108,22 @@ impl<'a> Diff<'a> {
     ) -> Comparison<'a> {
         // NOTE: The assumption is that checking for removals is probably usually easier,
         // so giving out downgrades for reviews is preferred:
-        let (closest_old_version, closest_old_info) =
-            old.range(&new_version..).next().unwrap_or_else(|| {
-                old.last_key_value()
-                    .expect("Higher ones were already checked, version set is never empty")
-            });
+        let old_this = old.get_key_value(&new_version);
+        let old_prev = old.range(..&new_version).next_back();
+        let old_next = old.range(&new_version..).next();
+        let (closest_old_version, closest_old_info) = match (old_this, old_prev, old_next) {
+            (None, Some(prev), Some(next)) => {
+                if version_diff(prev.0, &new_version) <= version_diff(next.0, &new_version) {
+                    prev
+                } else {
+                    next
+                }
+            }
+            (Some(out), _, _) | (None, Some(out), None) | (None, None, Some(out)) => out,
+            (None, None, None) => unreachable!(
+                "There should be different versions if it wasn't added or stayed the same"
+            ),
+        };
 
         let closest_different_old_version =
             (*closest_old_version != new_version).then(|| closest_old_version.clone());

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -262,7 +262,7 @@ impl<'a> Diff<'a> {
         };
 
         let filtered_added = in_right_set(&old.filtered, &new.filtered);
-        let filtered_removed = in_right_set(&old.filtered, &new.filtered);
+        let filtered_removed = in_right_set(&new.filtered, &old.filtered);
 
         Diff {
             added,

--- a/src/indexed.rs
+++ b/src/indexed.rs
@@ -5,9 +5,9 @@
 use std::{collections::HashMap, path::Path};
 
 use crate::Platform;
+use anyhow::Result;
 use camino::Utf8PathBuf;
 use cargo_metadata::{MetadataCommand, Node, Package, PackageId};
-use anyhow::Result;
 
 /// The indexed output of `cargo metadata`
 #[derive(Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,8 @@ use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use anyhow::{Result, anyhow, bail};
 use clap::Parser;
-use anyhow::{Result, bail, anyhow};
 use crates_io_api::SyncClient;
 use semver::Version;
 use serde::Serialize;

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -5,9 +5,9 @@
 
 use crate::Platform;
 use crate::indexed::IndexedMetadata;
+use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use cargo_metadata::PackageId;
-use anyhow::Result;
 use semver::Version;
 use serde::Serialize;
 use std::{


### PR DESCRIPTION
This:
* Runs `cargo fmt`
* Fixes removed versions outside of platforms showing added ones instead
* Changes the preferred version selection for diffs to always select the closest version